### PR TITLE
Clear log on reset and streamline controls

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -19,8 +19,8 @@ Perfekt für Einsteiger, die Sortieralgorithmen Schritt für Schritt verstehen m
 - Steuerung:
   - Start – startet die Animation
   - Pause/Fortsetzen – stoppt und setzt fort
-  - Reset – Eingabe neu beginnen
-  - Geschwindigkeit – Regler für Animations-Tempo
+  - Reset – Eingabe neu beginnen (inkl. geleertem Log)
+- Zeitmessung: Exakte Stoppuhr, die automatisch mit dem Sortiervorgang stoppt
 - Schrittlogik: Alle Algorithmen liefern fein granular Schritte, sodass die Visualisierung konsistent bleibt
 
 🛠️ Voraussetzungen


### PR DESCRIPTION
## Summary
- remove the animation speed slider and rely on a consistent default tempo
- add a bold algorithm heading to the explanation panel and clear the run log on reset
- tighten the stopwatch update cadence so it stops precisely with the animation

## Testing
- python -m compileall bubble_sort_visualizer.py

------
https://chatgpt.com/codex/tasks/task_b_68d2083dc9b4832f81d3220b212ba7c5