### PR TITLE
Stop timer when final bar is sorted

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,27 +1,40 @@
-AGENTS.md
+Projektüberblick
+=================
+Dieses Repository enthält eine vollständig implementierte tkinter-Anwendung,
+die sechs Sortieralgorithmen (Bubble, Selection, Insertion, Merge, Quick und
+Heap) visuell darstellt. Nutzerinnen und Nutzer geben exakt fünf Zahlen ein;
+das Programm animiert die Sortierschritte als Balkendiagramm mit einem
+konsistenten Farbschema (Grau für unsortiert, Gelb für Vergleiche, Rot für
+Schreiboperationen und Grün für endgültig sortierte Werte).
 
-Goal
-This agent should develop and maintain a Python program that graphically visualizes and animates multiple sorting algorithms: Bubble Sort, Selection Sort, Insertion Sort, Merge Sort, Quick Sort, and Heap Sort. The project is designed for learning and demonstration purposes, helping beginners understand sorting algorithms step by step.
+Aktueller Funktionsumfang
+-------------------------
+* Radiobuttons zur Auswahl des Sortierverfahrens und Schaltflächen für Start,
+  Pause/Fortsetzen sowie Reset.
+* Eine Infobox, die Vorteile und Nachteile des gewählten Algorithmus
+  beschreibt, sowie eine Tabelle mit den Zeiten der letzten Durchläufe.
+* Eine Stoppuhr, die beim Start automatisch losläuft und exakt in dem Moment
+  stoppt, in dem alle Balken grün markiert sind.
+* Schrittgeneratoren für alle unterstützten Algorithmen; jeder Schritt ist als
+  Tupel `(aktion, index, optionaler_index_oder_wert)` aufgebaut.
 
-Context
-- Language & Environment: Python 3.8+, standard library only (tkinter for GUI/animation)
-- Input: 5 freely chosen numbers (also multi-digit, e.g., 8, 12, 88, 75, 106)
-- Visualization: Bar chart in a Canvas, consistent color codes (Gray / Yellow / Red / Green)
-- UI Controls: Start, Pause/Resume, Reset, Speed slider
-- Algorithm Selection: Option buttons (radio buttons) for Bubble, Selection, Insertion, Merge, Quick, Heap
-- Architecture: GUI separated from algorithm logic; each algorithm produces a step sequence (comparisons, swaps, markings) consumed by the visualizer
+Arbeitsrichtlinien
+------------------
+* Bewahre die klare Trennung zwischen Schrittgeneratoren und Rendererlogik.
+* Verwende sprechende Namen, Typannotationen und aussagekräftige Kommentare,
+  um den didaktischen Charakter des Projekts zu erhalten.
+* Halte die Farb- und Ereignis-Semantik bei (`compare`, `swap`, `overwrite`,
+  `revert`, `mark_sorted`). Neue Ereignistypen sollten nur mit gutem Grund
+  eingeführt werden.
+* Animationen müssen über `after`-Callbacks laufen, damit die Oberfläche nicht
+  blockiert. Achte darauf, dass Timer und Animationen sauber beendet werden,
+  sobald ein Lauf fertig ist.
 
-Agent Behavior
-- Clear, well-structured, and commented code; use meaningful variable names
-- Didactics: Explicitly model the steps of algorithms (events with type, indices, optional values/colors)
-- Robustness: Validate input (exactly 5 integers), report errors via dialogs
-- Consistency: Unified event and color semantics across all algorithms
-- Performance: Animation using tkinter's after-callbacks with adjustable delay, no UI blocking
-- Extensibility: New algorithms can be added as step generators without changing the renderer
-
-Tasks
-- Implement the six sorting algorithms as step generators (yielding comparison/swap/mark events)
-- Build a GUI with input fields, option buttons for algorithm selection, control buttons, and a speed slider
-- Create a renderer that translates events into Canvas updates (set colors, swap bar positions, mark as final)
-- Ensure that pause/resume and reset correctly manage the animation state
-- Perform manual tests for typical and edge cases
+Tests und Validierung
+---------------------
+* Es existieren keine automatisierten Tests. Prüfe Änderungen manuell, indem
+  du `python bubble_sort_visualizer.py` startest und mehrere Algorithmen mit
+  unterschiedlichen Eingaben durchspielst.
+* Kontrolliere dabei insbesondere, dass die Stoppuhr unmittelbar anhält,
+  sobald der letzte Balken grün eingefärbt wird, und dass Pause/Reset weiterhin
+  zuverlässig funktionieren.

--- a/Readme.txt
+++ b/Readme.txt
@@ -9,8 +9,7 @@ Perfekt für Einsteiger, die Sortieralgorithmen Schritt für Schritt verstehen m
 - Eingabe: 5 Zahlen frei wählbar (ein- oder mehrstellig, z. B. 8, 12, 88, 75, 106)
 - Algorithmus-Auswahl: Über Option-Buttons (Radio-Buttons) wählbar:
   Bubble, Selection, Insertion, Merge, Quick, Heap
-- Visualisierung: Darstellung der Werte als Balkendiagramm
-- Animation: Jeder Vergleich und jeder Tausch/Schritt wird hervorgehoben
+- Visualisierung: Darstellung der Werte als Balkendiagramm mit farblicher Hervorhebung jeder Aktion
 - Farbcodierung:
   - Grau = Ausgangszustand
   - Gelb = Vergleich
@@ -20,7 +19,8 @@ Perfekt für Einsteiger, die Sortieralgorithmen Schritt für Schritt verstehen m
   - Start – startet die Animation
   - Pause/Fortsetzen – stoppt und setzt fort
   - Reset – Eingabe neu beginnen (inkl. geleertem Log)
-- Zeitmessung: Exakte Stoppuhr, die automatisch mit dem Sortiervorgang stoppt
+- Algorithmus-Info: Rechte Seitenleiste mit Beschreibung, Vorteilen/Nachteilen und Tabelle der letzten Rundenzeiten
+- Zeitmessung: Stoppuhr startet automatisch mit dem Lauf und hält exakt in dem Moment an, in dem der letzte Balken grün wird
 - Schrittlogik: Alle Algorithmen liefern fein granular Schritte, sodass die Visualisierung konsistent bleibt
 
 🛠️ Voraussetzungen


### PR DESCRIPTION
## Summary
- stop the animation timer as soon as the last bar is marked green and avoid rescheduling callbacks after finishing
- guard the finalisation logic to cancel pending callbacks safely and prevent duplicate completion handling
- refresh the project documentation and agent guidelines to reflect the current feature set and testing expectations

## Testing
- python -m compileall bubble_sort_visualizer.py

------
https://chatgpt.com/codex/tasks/task_b_68d20b9067c8832fa3397a5b344d22fa